### PR TITLE
[FIX] Operators: String format statements should use correct escaping…

### DIFF
--- a/sharping-spring-data/src/main/java/net/seesharpsoft/spring/data/jpa/expression/Operators.java
+++ b/sharping-spring-data/src/main/java/net/seesharpsoft/spring/data/jpa/expression/Operators.java
@@ -232,7 +232,7 @@ public class Operators {
 
         @Override
         protected Expression createExpression(From root, AbstractQuery query, CriteriaBuilder builder, Expression left, String right) {
-            return builder.like(left, String.format("\\%%s\\%", right));
+            return builder.like(left, String.format("%%%s%%", right));
         }
     };
     public static final Operator STARTS_WITH = new LikeOperatorBase("startsWith", 90) {
@@ -243,7 +243,7 @@ public class Operators {
 
         @Override
         protected Expression createExpression(From root, AbstractQuery query, CriteriaBuilder builder, Expression left, String right) {
-            return builder.like(left, String.format("%s\\%", right));
+            return builder.like(left, String.format("%s%%", right));
         }
     };
     public static final Operator ENDS_WITH = new LikeOperatorBase("endsWith", 90) {
@@ -254,7 +254,7 @@ public class Operators {
 
         @Override
         protected Expression createExpression(From root, AbstractQuery query, CriteriaBuilder builder, Expression left, String right) {
-            return builder.like(left, String.format("\\%%s", right));
+            return builder.like(left, String.format("%%%s", right));
         }
     };
 

--- a/sharping-spring-data/src/test/java/net/seesharpsoft/spring/data/jpa/expression/OperatorsUT.java
+++ b/sharping-spring-data/src/test/java/net/seesharpsoft/spring/data/jpa/expression/OperatorsUT.java
@@ -1,18 +1,16 @@
 package net.seesharpsoft.spring.data.jpa.expression;
 
+import javafx.util.Pair;
 import net.seesharpsoft.spring.test.mock.CriteriaBuilderMockBuilder;
 import net.seesharpsoft.spring.test.mock.CriteriaQueryMockBuilder;
 import net.seesharpsoft.spring.test.mock.ExpressionMockBuilder;
 import org.junit.Test;
-import javafx.util.Pair;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
-
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -95,6 +93,16 @@ public class OperatorsUT {
         Root root = ExpressionMockBuilder.newRoot(null);
 
         Operators.NOT.createExpression(root, query, builder);
+    }
+
+    @Test
+    public void startsWith_operator_should_create_a_working_condition() {
+        CriteriaBuilder builder = CriteriaBuilderMockBuilder.newCriteriaBuilder();
+        CriteriaQuery query = CriteriaQueryMockBuilder.newCriteriaQuery();
+        Root root = ExpressionMockBuilder.newRoot(null);
+
+        Expression expression = Operators.STARTS_WITH.createExpression(root, query, builder, "PATH", "NEEDLE");
+        assertThat(expression.toString(), is("like('PATH', NEEDLE%)"));
     }
 
     @Test


### PR DESCRIPTION
… of % sign
The resulting LIKE statement still looks strange. I couldn't test it against a real database. You should definitely do it, before merging.